### PR TITLE
Check for null value due to PHP8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php:
   - 7.2
   - 7.4
+  - nightly
 
 env:
   global:

--- a/src/Decimal.php
+++ b/src/Decimal.php
@@ -81,7 +81,7 @@ class Decimal implements JsonSerializable
      */
     protected function parseValue($value): string
     {
-        if (!(is_scalar($value) || method_exists($value, '__toString'))) {
+        if ($value !== null && !(is_scalar($value) || method_exists($value, '__toString'))) {
             throw new InvalidArgumentException('Invalid value');
         }
 

--- a/tests/DecimalTest.php
+++ b/tests/DecimalTest.php
@@ -7,10 +7,12 @@
 
 namespace SprykerTest\DecimalObject;
 
+use DivisionByZeroError;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Spryker\DecimalObject\Decimal;
 use stdClass;
+use TypeError;
 
 class DecimalTest extends TestCase
 {
@@ -392,7 +394,7 @@ class DecimalTest extends TestCase
     {
         $decimal = Decimal::create($value);
 
-        $this->expectException(\TypeError::class);
+        $this->expectException(TypeError::class);
         $this->expectErrorMessage('Cannot cast Big Decimal to Float');
 
         $result = $decimal->toFloat();
@@ -432,7 +434,7 @@ class DecimalTest extends TestCase
     {
         $decimal = Decimal::create($value);
 
-        $this->expectException(\TypeError::class);
+        $this->expectException(TypeError::class);
         $this->expectErrorMessage('Cannot cast Big Integer to Integer');
 
         $decimal->toInt();
@@ -953,7 +955,7 @@ class DecimalTest extends TestCase
     {
         $decimal = Decimal::create(1);
 
-        $this->expectException(\DivisionByZeroError::class);
+        $this->expectException(DivisionByZeroError::class);
 
         $decimal->divide(0, 10);
     }


### PR DESCRIPTION
patch release

without this it fails in PHP due to its own type checks:

`Failed asserting that exception of type "TypeError" matches expected exception "InvalidArgumentException". Message was: "method_exists(): Argument #1 ($object_or_class) must be of type object|string, null given" at
decimal-object/src/Decimal.php:84`